### PR TITLE
Add call to auth_token on initialize

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,8 @@ ProfitWell.prototype.initialize = function() {
   var id = new Identify({ traits: traits });
   var email = id.email();
 
+  window.profitwell('auth_token', this.options.publicApiToken);
+
   if (email) {
     this.start(email);
   } 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@profitwell/analytics.js-integration",
   "description": "The Profitwell DotJS analytics.js integration.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -12,6 +12,7 @@ describe('Profitwell', function() {
     publicApiToken: '123123123'
   };
   var testEmail = 'testEmail@pw.com';
+  var testToken = 'test_token';
 
   beforeEach(function() {
     analytics = new Analytics();
@@ -36,6 +37,7 @@ describe('Profitwell', function() {
       beforeEach(function() {
         analytics.stub(profitwell, 'load');
         analytics.stub(profitwell, 'start');
+        analytics.stub(window, 'profitwell');
       });
 
       it('should call load on initialize', function() {
@@ -48,6 +50,14 @@ describe('Profitwell', function() {
         analytics.initialize();
 
         analytics.assert(window.profitwell instanceof Function);
+      });
+
+      it('should call auth_token with the token', () => {
+        profitwell.options.publicApiToken = testToken;
+
+        analytics.initialize();
+
+        analytics.called(window.profitwell, 'auth_token', testToken);
       });
 
       it('should call start with email on initialize', function() {


### PR DESCRIPTION
The usual snippet install would have a `data-pw-auth` property in the script tag that is used to construct the async script tag that is not necessary in the Segment integration since they handle that for us. However, the property is also used to set the authorization header on any request to our backend, so with it missing every call is resulting in a 401.